### PR TITLE
Added: random_id for cloudsql

### DIFF
--- a/modules/mysql/main.tf
+++ b/modules/mysql/main.tf
@@ -31,10 +31,14 @@ locals {
   backups_enabled    = var.availability_type == "REGIONAL" ? true : lookup(var.backup_configuration, "enabled", null)
 }
 
+resource "random_id" "prefix" {
+  byte_length = 4
+}
+
 resource "google_sql_database_instance" "default" {
   provider            = google-beta
   project             = var.project_id
-  name                = var.name
+  name                = "${var.name}-${random_id.prefix.hex}"
   database_version    = var.database_version
   region              = var.region
   encryption_key_name = var.encryption_key_name


### PR DESCRIPTION
There is an issue if you would like to create a DB with the same name. With the current approach, you need to change the name every time or you have to work around and use something like `random_id`

> **If I delete my instance, can I reuse the instance name?**
> Yes, but not right away. The instance name is unavailable for up to a week before it can be reused.

More information is here [Managing Your Instances](https://cloud.google.com/sql/faq?hl=en#managing-your-instances)